### PR TITLE
Visually highlight deprecated options and place them at the end of the option list

### DIFF
--- a/front-end/src/components/Option.jsx
+++ b/front-end/src/components/Option.jsx
@@ -18,7 +18,7 @@ const Option = ({ optionInfo,
     switch (optionInfo.title) {
 
       case "AlignTrailingComments":
-        if (optionInfo.values.length == 1)
+        if (optionInfo.values.length === 1)
           return (<SingleSelector
             key={optionInfo.title}
             selectorInfo={optionInfo.values[0]}
@@ -65,6 +65,7 @@ const Option = ({ optionInfo,
   }
 
 
+
   return (
     <section className={styles.option}>
       <span className={styles.title_container}>
@@ -79,7 +80,7 @@ const Option = ({ optionInfo,
             src="./questionIcon.svg"
           />
         </button>
-        <span className={styles.title}>{optionInfo.title}</span>
+        <span className={optionInfo.deprecated ? styles.title_deprecated : styles.title}>{optionInfo.title}</span>
         <Collapsible open={showDocString} transitionTime={100}>
           <div
             hidden={showDocString ? "" : "hidden"}

--- a/front-end/src/components/Option.module.css
+++ b/front-end/src/components/Option.module.css
@@ -12,6 +12,13 @@
   overflow: hidden;
 }
 
+.title_deprecated {
+  font-family: sans-serif;
+  font-size: 17px;
+  overflow: hidden;
+  text-decoration: line-through
+}
+
 :global(.dark) .title {
   color: #cfcec4;
 }

--- a/front-end/src/components/OptionList.jsx
+++ b/front-end/src/components/OptionList.jsx
@@ -5,6 +5,32 @@ import { useCookies } from "react-cookie";
 
 const OptionList = ({ config, options, llvmVersionOption, onOptionChange, updateModifiedList, onFreshGeneratedOptions }) => {
   const [_, setCookie] = useCookies([]); // ultra mega bruh
+
+  const deprecatedOptions = []
+  const nonDeprecatedOptions = config[options.selectedVersion].slice(1).map((option) => {
+    const optionWgt = (<Option
+      key={option.title}
+      optionInfo={option}
+      currentStyle={options.BasedOnStyle}
+      currentOptionValue={options[option.title]}
+      onChange={(optionTitle, newOptionValue) => {
+        updateModifiedList(optionTitle)
+        onOptionChange({
+          ...options,
+          [optionTitle]: newOptionValue
+        })
+      }
+      }
+    />
+    )
+    if (option.deprecated) {
+      deprecatedOptions.push(optionWgt)
+      return []
+    }
+    return optionWgt
+  })
+
+
   return (
     <div className="OptionList">
       <Option //LLVM version option
@@ -40,17 +66,17 @@ const OptionList = ({ config, options, llvmVersionOption, onOptionChange, update
             return;
           }
 
-          let st = {
+          let optionsStateTemplate = {
             selectedVersion: options.selectedVersion,
             BasedOnStyle: newOptionValue
           }
-          config[st.selectedVersion]
+          config[optionsStateTemplate.selectedVersion]
             .slice(1).forEach((option) => {
               if (
                 option.values.length === 1 &&
                 option.values[0].defaults[newOptionValue] !== undefined
               ) {
-                st[option.title] =
+                optionsStateTemplate[option.title] =
                   option.values[0].defaults[newOptionValue].value;
               } else {
                 // set all option values to selected style defaults
@@ -58,34 +84,20 @@ const OptionList = ({ config, options, llvmVersionOption, onOptionChange, update
                 // filter out options without defaults for this style
                 option.values.filter((element) => element.defaults[newOptionValue] !== undefined)
                   .forEach((nestedOption) => {
-                    if (st[option.title] == undefined)
-                      st[option.title] = {}
-                    st[option.title][nestedOption.title] =
+                    if (optionsStateTemplate[option.title] == undefined)
+                      optionsStateTemplate[option.title] = {}
+                    optionsStateTemplate[option.title][nestedOption.title] =
                       nestedOption.defaults[newOptionValue].value
                   }
                   );
               }
             });
-          onFreshGeneratedOptions(cloneDeep(st))
-          onOptionChange(st);
+          onFreshGeneratedOptions(cloneDeep(optionsStateTemplate))
+          onOptionChange(optionsStateTemplate);
         }}
       />
-      {config[options.selectedVersion].slice(1).map((option) => (
-        <Option
-          key={option.title}
-          optionInfo={option}
-          currentStyle={options.BasedOnStyle}
-          currentOptionValue={options[option.title]}
-          onChange={(optionTitle, newOptionValue) => {
-            updateModifiedList(optionTitle)
-            onOptionChange({
-              ...options,
-              [optionTitle]: newOptionValue
-            })
-          }
-          }
-        />
-      ))}
+      {nonDeprecatedOptions}
+      {deprecatedOptions}
     </div>
   )
 


### PR DESCRIPTION
Add new config field with option deprecation status, place deprecated options at the end of the option list with different title style. Highlight word **deprecated** in documentation text